### PR TITLE
fix: CI skip tag issue preventing npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.version.outputs.bump != 'none'
         id: bump
         run: |
-          npm version ${{ steps.version.outputs.bump }} -m "chore: release %s [skip ci]"
+          npm version ${{ steps.version.outputs.bump }} -m "chore: release %s"
           VERSION="v$(node -p "require('./package.json').version")"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           


### PR DESCRIPTION
## 概要
リリースワークフローで作成されるコミットメッセージから `[skip ci]` フラグを削除しました。

## 問題
- リリース時のコミットメッセージに `[skip ci]` が含まれていた
- これによりタグプッシュ時にPublish to npmワークフローがトリガーされない
- 手動でworkflow_dispatchを実行する必要があった

## 修正内容
`.github/workflows/release.yml` の63行目から `[skip ci]` を削除：
```diff
- npm version ${{ steps.version.outputs.bump }} -m "chore: release %s [skip ci]"
+ npm version ${{ steps.version.outputs.bump }} -m "chore: release %s"
```

## 影響
- タグプッシュ時に自動的にnpmパブリッシュワークフローが実行されるようになる
- 無限ループの心配はない（リリースワークフローとパブリッシュワークフローは異なるトリガー）

## テスト
この修正をマージ後、次回のリリースで正常に動作することを確認予定