### PR TITLE
chore: revert version to 1.0.0 for testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sfn-test",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sfn-test",
-      "version": "1.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.61.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sfn-test",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "AI-powered local testing tool for AWS Step Functions",
   "keywords": [
     "aws",


### PR DESCRIPTION
## 概要
リリースワークフローのテストのため、一時的にバージョンを1.0.0に戻します。

## 背景
- v1.1.0のリリースワークフローで`[skip ci]`の問題があった
- CI修正後、正しくリリースワークフローが動作することを確認したい
- package.jsonが既に1.1.0になっているため、一度1.0.0に戻す必要がある

## 次のステップ
1. このPRをマージ
2. release/v1.1.0ブランチを作成
3. リリースPRを作成して`release:minor`ラベルを付与
4. マージして自動的にv1.1.0がタグ付けされ、npmパブリッシュが実行されることを確認

## 注意
これは一時的な変更で、すぐに正しいリリースフローでv1.1.0に戻ります。