### PR TITLE
ci: npm publishをOIDC Trusted Publishingに移行

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # npm provenance用（オプション）
+      id-token: write # OIDC Trusted Publishing用
 
     steps:
       - name: Checkout code
@@ -64,7 +64,9 @@ jobs:
           PACKAGE_VERSION="v$(node -p "require('./package.json').version")"
           echo "Publishing version: $PACKAGE_VERSION"
 
+      # npm CLI 11.5.1以上が必要（Trusted Publishing対応）
+      - name: Update npm for Trusted Publishing
+        run: npm install -g npm@latest
+
       - name: Publish to npm
-        run: pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   ],
   "author": "TAKEDA-Takashi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TAKEDA-Takashi/sfn-ai-local-test.git"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- npm publishの認証をNPM_TOKENからOIDC Trusted Publishingに移行
- Provenance（来歴証明）付きでパブリッシュ
- v1.6.0のタグは作成済みのため、マージ後にワークフローを手動実行してリリース

## 変更内容

### publish.yml
- `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` を削除
- `npm install -g npm@latest` でTrusted Publishing対応のnpm CLIをインストール
- `npm publish --provenance --access public` でprovenance付きパブリッシュ

### package.json
- `repository`フィールドを追加（Trusted Publishingの要件）

### RELEASE.md
- セットアップ手順をOIDC Trusted Publishing用に更新
- npmjs.comでのTrusted Publisher設定手順を追加

## マージ後の手順
1. npmjs.comでTrusted Publisherを設定:
   `https://www.npmjs.com/package/sfn-test/access`
2. `gh run rerun 22431099927` または手動でPublishワークフローを実行

## Test plan
- [x] ワークフロー構文の確認
- [x] `id-token: write`パーミッション設定済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)